### PR TITLE
Add Travis-CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+install:
+  - wget http://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz -O - | sudo tar zxf - --strip-components 1 -C /usr/local
+  - yes | sudo add-apt-repository ppa:cmrx64/cargo
+  - sudo apt-get update
+  - sudo apt-get install cargo
+script:
+  - cargo build
+  - cargo test
+os:
+  - linux
+


### PR DESCRIPTION
Runs cargo build, so ensures compilation, but this won't run the tests yet.

You'll also have to turn on travis integration for this repo on their website.
