### PR TITLE
Replace HashMap<&'static str, Box<Any>> with TypeMap.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,10 @@ extern crate semver;
 use std::collections::HashMap;
 use std::io::net::ip::IpAddr;
 use std::hash::Hash;
-use std::any::Any;
 use std::fmt::Show;
+
+pub use self::typemap::TypeMap;
+mod typemap;
 
 #[deriving(PartialEq, Show, Clone)]
 pub enum Scheme {
@@ -38,7 +40,7 @@ pub enum Method {
 }
 
 /// A Dictionary for extensions provided by the server or middleware
-pub type Extensions = HashMap<&'static str, Box<Any>>;
+pub type Extensions = TypeMap;
 
 pub trait Request {
     /// The version of HTTP being used

--- a/src/typemap.rs
+++ b/src/typemap.rs
@@ -1,0 +1,30 @@
+use std::any::{Any, AnyMutRefExt, AnyRefExt};
+use std::intrinsics::TypeId;
+use std::collections::HashMap;
+
+pub struct TypeMap {
+    data: HashMap<TypeId, Box<Any>>
+}
+
+impl TypeMap {
+    pub fn find<T: 'static>(&self) -> Option<&T> {
+        self.data.find(&TypeId::of::<T>()).and_then(|a| a.downcast_ref())
+    }
+
+    pub fn find_mut<T: 'static>(&mut self) -> Option<&mut T> {
+        self.data.find_mut(&TypeId::of::<T>()).and_then(|a| a.downcast_mut())
+    }
+
+    pub fn insert<T: 'static>(&mut self, val: T) -> bool {
+        self.data.insert(TypeId::of::<T>(), box val as Box<Any>)
+    }
+
+    pub fn remove<T: 'static>(&mut self) -> bool {
+        self.data.remove(&TypeId::of::<T>())
+    }
+
+    pub fn contains<T: 'static>(&mut self) -> bool {
+        self.data.contains_key(&TypeId::of::<T>())
+    }
+}
+


### PR DESCRIPTION
TypeMap is a thin wrapper around `HashMap<TypeId, Box<Any>>` and is meant
to be a key-value store for up to one value of each type. It enables type-safe
extensions to Request and provides a much friendlier interface than the map
it is replacing, which called on users to do runtime downcasting.

@wycats If you want to make this slightly faster we can depend on
https://github.com/reem/rust-unsafe-any, but I think the real speed boost
comes from implementing a specific hasher for TypeId.
