### PR TITLE
Publicly re-export semver

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate semver;
+pub extern crate semver;
 
 use std::io::prelude::*;
 use std::io;


### PR DESCRIPTION
There are a bunch of crates which need to use the same version of
`semver` as this one, but have no real need to constrain the version or
depend on `semver` directly. This allows them to use `conduit::semver`
instead.