### PR TITLE
Improve the `conduit::Body` type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conduit"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 authors = ["wycats@gmail.com",
            "Alex Crichton <alex@alexcrichton.com>"]
 description = "Common HTTP server interface"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["wycats@gmail.com",
 description = "Common HTTP server interface"
 license = "MIT"
 repository = "https://github.com/conduit-rust/conduit"
+edition = "2018"
 
 [dependencies]
 http = "0.2"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.0.1"
 authors = ["Example User <mail@example.com>"]
 
 [dependencies]
-civet = "0.12.0-alpha.2"
-conduit = "0.9.0-alpha.1"
-conduit-router = "0.9.0-alpha.1"
+civet = "0.12.0-alpha.3"
+conduit = "0.9.0-alpha.2"
+conduit-router = "0.9.0-alpha.2"

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -5,17 +5,17 @@ extern crate conduit_router;
 use std::sync::mpsc::channel;
 
 use civet::{Config, Server};
-use conduit::{static_to_body, vec_to_body, HttpResult, RequestExt, Response};
+use conduit::{Body, HttpResult, RequestExt, Response};
 use conduit_router::{RequestParams, RouteBuilder};
 
 fn name(req: &mut dyn RequestExt) -> HttpResult {
     let name = req.params().find("name").unwrap();
     let bytes = format!("Hello {}!", name).into_bytes();
-    Response::builder().body(vec_to_body(bytes))
+    Response::builder().body(Body::from_vec(bytes))
 }
 
 fn hello(_req: &mut dyn RequestExt) -> HttpResult {
-    Response::builder().body(static_to_body(b"Hello world!"))
+    Response::builder().body(Body::from_static(b"Hello world!"))
 }
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![warn(rust_2018_idioms)]
 
-extern crate http;
-
 use std::error::Error;
 use std::fs::File;
 use std::io::Read;


### PR DESCRIPTION
The `WriteBody` trait was only used to support sending files via
`conduit-static` and child process standard output via
`conduit-git-http-backend`.

The git functionality is only used by crates.io in development mode, so
I have focused on file handling functionality.  The new structure allows
the blocking `civet` server to continue using `io::copy` while
`conduit-hyper` can turn the blocking `File` into an async
`tokio::fs::File` and free the background thread to handle other
requests.

For now, `conduit-git-http-backend` will fall back to buffering the
response into a `Vec<u8>` rather than streaming chunks of data as it
arrives from the child process.  This seems like an acceptable tradeoff
given the functionality is only used when doing local development within
a docker container.

r? @JohnTitor