### PR TITLE
router: Add `sentry` feature

### DIFF
--- a/conduit-router/Cargo.toml
+++ b/conduit-router/Cargo.toml
@@ -7,9 +7,14 @@ description = "Router middleware for conduit based on route-recognizer"
 repository = "https://github.com/conduit-rust/conduit"
 edition = "2018"
 
+[features]
+default = []
+sentry = ["sentry-core"]
+
 [dependencies]
 conduit = { version = "0.9.0-alpha.5", path = "../conduit" }
 route-recognizer = "0.3"
+sentry-core = { version = "0.23.0", optional = true }
 thiserror = "1.0.30"
 tracing = "0.1.29"
 

--- a/conduit-router/src/lib.rs
+++ b/conduit-router/src/lib.rs
@@ -126,6 +126,12 @@ impl conduit::Handler for RouteBuilder {
         let pattern = m.handler().pattern;
         debug!(pattern = pattern.0, "matching route handler found");
 
+        #[cfg(feature = "sentry")]
+        {
+            let transaction = Some(pattern.pattern());
+            sentry_core::configure_scope(|scope| scope.set_transaction(transaction))
+        }
+
         {
             let extensions = request.mut_extensions();
             extensions.insert(pattern);


### PR DESCRIPTION
If this feature is used then the `transaction` of the active `scope` is set to the route pattern that was used. This is roughly similar to how it is implemented in sentry-actix (see https://github.com/getsentry/sentry-rust/blob/0.23.0/sentry-actix/src/lib.rs#L258-L262).