### PR TITLE
conduit-static: Remove `#[allow(deprecated)]` attribute

### DIFF
--- a/conduit-static/src/lib.rs
+++ b/conduit-static/src/lib.rs
@@ -20,7 +20,6 @@ impl Static {
 }
 
 impl Handler for Static {
-    #[allow(deprecated)]
     fn call(&self, request: &mut dyn RequestExt) -> HandlerResult {
         let request_path = &request.path()[1..];
         if request_path.contains("..") {


### PR DESCRIPTION
This function does not appear to use anything that is deprecated, and we should generally not allow using known deprecated code.