### PR TITLE
Bump up MSRV to 1.49

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   # minimum supported rust version
-  MSRV: 1.46.0
+  MSRV: 1.49
 
 jobs:
   check:


### PR DESCRIPTION
...because the http crate bumped up its MSRV to that version in 0.2.7: https://github.com/hyperium/http/blob/master/CHANGELOG.md#027-april-28-2022
I don't think this has a significant effect, it should be fairly safe.