### PR TITLE
Run rustfmt on 1.62

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: rustup override set ${{env.MSRV}}
+      - run: rustup override set 1.62
       - run: rustup component add rustfmt
       - uses: Swatinem/rust-cache@v2.0.0
       - run: cargo fmt --all -- --check


### PR DESCRIPTION
The rustfmt's behavior on stable rarely changes so running it on stable is generally painless, I think. Actually running it on MSRV causes an unwanted failure: https://github.com/conduit-rust/conduit/runs/7373430496?check_suite_focus=true

Signed-off-by: Yuki Okushi <jtitor@2k36.org>