### PR TITLE
Bump up MSRV to 1.56

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   # minimum supported rust version
-  MSRV: 1.49
+  MSRV: 1.56
 
 jobs:
   check:

--- a/conduit-router/src/lib.rs
+++ b/conduit-router/src/lib.rs
@@ -108,7 +108,7 @@ impl conduit::Handler for RouteBuilder {
             let method = request.method();
             let path = request.path();
 
-            match self.recognize(&method, path) {
+            match self.recognize(method, path) {
                 Ok(m) => m,
                 Err(e) => {
                     info!("{}", e);


### PR DESCRIPTION
once_cell 1.15.0 needs it: https://github.com/conduit-rust/conduit/actions/runs/3212974184/jobs/5252296257
Since conduit-hyper's MSRV is 1.56, I don't think this makes a big difference.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>