### PR TITLE
Update tracing and fix Clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: rustup override set ${{env.MSRV}}
+      - run: rustup override set 1.62
       - run: rustup component add clippy
       - uses: Swatinem/rust-cache@v2.2.0
-      - run: cargo clippy --workspace -- --deny warnings --allow clippy::suspicious_else_formatting
+      - run: cargo clippy --workspace -- --deny warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/conduit-router/Cargo.toml
+++ b/conduit-router/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 conduit = { version ="0.10.0", path = "../conduit" }
 route-recognizer = "0.3"
 thiserror = "1.0.37"
-tracing = "0.1.36"
+tracing = "0.1.37"
 
 [dev-dependencies]
 conduit-test = { version ="0.10.0", path = "../conduit-test" }

--- a/conduit-router/src/lib.rs
+++ b/conduit-router/src/lib.rs
@@ -1,5 +1,4 @@
 #![warn(rust_2018_idioms)]
-#![allow(clippy::suspicious_else_formatting)]
 
 #[macro_use]
 extern crate tracing;


### PR DESCRIPTION
1.56 Clippy has a weird bug that is related to macros or tracing items and it causes immoral warnings, like:
```
error: this looks like an `else {..}` but the `else` is missing
  --> conduit-router/src/lib.rs:70:11
   |
70 |     ) -> &mut Self {
   |           ^^^^^^^^^
   |
   = note: to remove this lint, add the missing `else` or add a new line before the next block
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_else_formatting
```

It might be related to https://github.com/rust-lang/rust-clippy/issues/6249, this resolves that issue by using 1.62, which is used by rustfmt CI.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>