### PR TITLE
Add deprecating `README` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+This project had been used by the [crates.io](https://github.com/rust-lang/crates.io)
+project, but has since been replaced and is no longer maintained!
+
+Check out the [`web-programming::http-server`](https://crates.io/categories/web-programming::http-server)
+category on crates.io for possible alternatives.


### PR DESCRIPTION
This project is no longer being used by crates.io, so this PR adds a README file that finally deprecates it and marks it as unmaintained.